### PR TITLE
rm bootstrap-vue

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,6 @@
   },
   "dependencies": {
     "axios": "^0.16.1",
-    "bootstrap": "^4.0.0-alpha.6",
-    "bootstrap-vue": "^0.13.1",
     "moment": "^2.18.1",
     "vue": "^2.3.3",
     "vue-axios": "^2.0.2",

--- a/src/main.js
+++ b/src/main.js
@@ -4,18 +4,13 @@ import Vue from 'vue';
 import axios from 'axios';
 import VueAxios from 'vue-axios';
 import moment from 'moment';
-import BootstrapVue from 'bootstrap-vue/dist/bootstrap-vue.esm';
 
-// Import the styles directly. (Or you could add them via script tags.)
-import 'bootstrap/dist/css/bootstrap.css';
-import 'bootstrap-vue/dist/bootstrap-vue.css';
 
 import App from './App';
 import router from './router';
 import store from './store';
 
 Vue.use(VueAxios, axios);
-Vue.use(BootstrapVue);
 
 Vue.config.productionTip = false;
 


### PR DESCRIPTION
Removed bootstrap and boostrap vue from project so we can rely solely on CDN
This fixes:
1. header display
2. footer accent colors