### PR TITLE
.tag-default instead of .label-default

### DIFF
--- a/src/components/TagList.vue
+++ b/src/components/TagList.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="tag-list">
-    <a v-for="(tag, index) in tags" href="" class="label label-pill label-default">{{tag}}</a>
+    <a v-for="(tag, index) in tags" href="" class="tag-pill tag-default">{{tag}}</a>
   </div>
 </template>
 


### PR DESCRIPTION
#### Bug
Tag list display tags inline:
<img width="444" alt="screen shot 2017-05-19 at 01 57 12" src="https://cloud.githubusercontent.com/assets/2429708/26216396/80d29cb4-3c36-11e7-891f-54e562489c56.png">

#### Fix
Apply correct class `.tag-default instead` of `.label-default`

#### Result
<img width="446" alt="screen shot 2017-05-19 at 01 59 06" src="https://cloud.githubusercontent.com/assets/2429708/26216462/c5b67634-3c36-11e7-90af-e798f5878b32.png">
